### PR TITLE
Feature: Module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.1",
   "description": "A Storybook addon, Save the screenshot image of your stories! via puppeteer.",
   "main": "lib/index.js",
+  "module": "src/index.js",
   "bin": {
     "storybook-chrome-screenshot": "lib/cli.js"
   },
@@ -30,6 +31,7 @@
   "homepage": "https://github.com/tsuyoshiwada/storybook-chrome-screenshot#readme",
   "files": [
     "lib",
+    "src",
     "CHANGELOG.md",
     "README.md",
     "LICENSE",


### PR DESCRIPTION
Add module entry to package.json.
This way webpack or rollup can use the ES6 module instead of the transpiled ES5 version from babel which includes a lot of shimed code.
If module import is supported the `src/index.js` file gets imported otherwise it falls back to `lib/index.js` when using `require`.
This will save quite a few bytes in the final bundle.

See: https://github.com/rollup/rollup/wiki/pkg.module