### PR TITLE
Use start command instead of paths

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -55,8 +55,6 @@ const exit = (message, code = 1) => {
   process.exit(code);
 };
 
-const bin = execSync('echo $(npm bin)', { encoding: 'utf-8' }).trim();
-
 const options = {
   port: program.port,
   host: program.host,
@@ -69,21 +67,8 @@ const options = {
   parallel: program.parallel,
   injectFiles: program.injectFiles,
   debug: program.debug,
-  cwd: path.resolve(bin, '..', '..'),
-  cmd: path.resolve(bin, 'start-storybook'),
+  cmd: 'npm run start-storybook',
 };
-
-const config = path.resolve(options.cwd, options.configDir, 'config.js');
-
-if (!fs.existsSync(options.cmd)) {
-  exit(`Storybook does not exists. First, let's setup a Storybook!
-    See: https://storybook.js.org/basics/quick-start-guide/`);
-}
-
-if (!fs.existsSync(config)) {
-  exit(`"${options.configDir}/config.js" does not exists.`);
-}
-
 
 (async () => {
   const store = new Store(options.filterKind, options.filterStory);

--- a/src/internal/server.js
+++ b/src/internal/server.js
@@ -40,9 +40,7 @@ const optionsToCommandArgs = (options) => {
 };
 
 const startStorybookServer = (options, logger) => new Promise((resolve, reject) => {
-  const { cmd, cwd } = options;
-  const args = optionsToCommandArgs(options);
-  const storybook = spawn(cmd, args, { cwd });
+  const storybook = spawn(options.cmd);
 
   storybook.stdout.on('data', (out) => {
     const str = out.toString().trim();


### PR DESCRIPTION
Removed shell calls to fetch `.bin` path as they don't work on Windows and fixed picking wrong command file (which is `start-storybook.cmd` on Windows) by using user-provided start command that is executed in current working directory.