### PR TITLE
Parallelize browser processes rather than pages

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,7 +71,7 @@ const options: CLIOptions = {
     store,
     terminal,
     new Server(options, terminal, spawn),
-    new Browser(store, options),
+    () => new Browser(store, options),
   );
 
   try {

--- a/src/core/app/Browser.ts
+++ b/src/core/app/Browser.ts
@@ -1,7 +1,6 @@
 import * as puppeteer from 'puppeteer';
 import { EventTypes } from '../constants';
 import { CLIOptions } from '../../models/options';
-import { createArray } from '../utils';
 import StoryStore from './StoryStore';
 import Page, { ConsoleHandler } from './Page';
 
@@ -25,8 +24,7 @@ export default class Browser {
     return this.browser.close();
   }
 
-  public createPages(url: string, consoleHandler: ConsoleHandler) {
-    return Promise.all(createArray(this.options.parallel).map(async () => {
+  public async createPage(url: string, consoleHandler: ConsoleHandler) {
       const page = new Page(
         await this.browser.newPage(),
         url,
@@ -47,6 +45,5 @@ export default class Browser {
       });
 
       return page;
-    }));
   }
 }

--- a/src/core/app/Browser.ts
+++ b/src/core/app/Browser.ts
@@ -25,25 +25,25 @@ export default class Browser {
   }
 
   public async createPage(url: string, consoleHandler: ConsoleHandler) {
-      const page = new Page(
-        await this.browser.newPage(),
-        url,
-        this.options,
-        consoleHandler,
-      );
+    const page = new Page(
+      await this.browser.newPage(),
+      url,
+      this.options,
+      consoleHandler,
+    );
 
-      await page.exposeFunction('readyComponentScreenshot', (index: number) => {
-        page.emit(EventTypes.COMPONENT_READY, index);
-      });
+    await page.exposeFunction('readyComponentScreenshot', (index: number) => {
+      page.emit(EventTypes.COMPONENT_READY, index);
+    });
 
-      await page.exposeFunction('getScreenshotStories', () => (
-        this.store.get()
-      ));
+    await page.exposeFunction('getScreenshotStories', () => (
+      this.store.get()
+    ));
 
-      await page.exposeFunction('failureScreenshot', (error: string) => {
-        throw new Error(error);
-      });
+    await page.exposeFunction('failureScreenshot', (error: string) => {
+      throw new Error(error);
+    });
 
-      return page;
+    return page;
   }
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -115,10 +115,6 @@ export const humanizeDuration = (timestamp: number) => {
   return arr.join(' ');
 };
 
-export const createArray = (length: number) => (
-  (new Array(length)).fill(null)
-);
-
 export type Task<T> = (idx: number) => Promise<T>;
 
 export const execParalell = <T>(tasks: Task<T>[], p: number = 1) => {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -119,6 +119,25 @@ export const createArray = (length: number) => (
   (new Array(length)).fill(null)
 );
 
+export type Task<T> = (idx: number) => Promise<T>;
+
+export const execParalell = <T>(tasks: Task<T>[], p: number = 1) => {
+  const copied = tasks.slice();
+  const results = [] as T[];
+  return Promise.all(_.range(p).map(i => {
+    return new Promise((res, rej) => {
+    function next(): Promise<number | void> {
+      const t = copied.shift();
+      if (!t) {
+        return Promise.resolve(res());
+      }
+      return t(i).then(r => results.push(r)).then(next).catch(err => rej(err));
+    }
+    return next();
+    });
+  })).then(() => results);
+};
+
 export const getStorybookEnv = () => (
   ((window as any).STORYBOOK_ENV as StorybookEnv) // tslint:disable-line: no-any
 );


### PR DESCRIPTION
I've created this for #7 :)

This PR makes parallelization in the `CAPTURE` phase more efficient. It because that considering TCP connection restrictions of Chromium, parallelization of browser processes can use CPU more efficiently than parallelization of pages in one browser process.