### PR TITLE
Allow configuring of Puppeteer launch config

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,20 +340,21 @@ $ $(npm bin)/storybook-chrome-screenshot --help
 
   Options:
 
-    -V, --version                 output the version number
-    -p, --port [number]           Storybook server port. (default: 9001)
-    -h, --host [string]           Storybook server host. (default: localhost)
-    -s, --static-dir <dir-names>  Directory where to load static files from.
-    -c, --config-dir [dir-name]   Directory where to load Storybook configurations from. (default: .storybook)
-    -o, --output-dir [dir-name]   Directory where screenshot images are saved. (default: __screenshots__)
-    --parallel [number]           Number of Page Instances of Puppeteer to be activated when shooting screenshots. (default: 4)
-    --filter-kind [regexp]        Filter of kind with RegExp. (example: "Button$")
-    --filter-story [regexp]       Filter of story with RegExp. (example: "^with\s.+$")
-    --inject-files <file-names>   Path to the JavaScript file to be injected into frame. (default: )
-    --browser-timeout [number]    Timeout milliseconds when Puppeteer opens Storybook. (default: 30000)
-    --silent                      Suppress standard output.
-    --debug                       Enable debug mode.
-    -h, --help                    output usage information
+    -V, --version                    output the version number
+    -p, --port [number]              Storybook server port. (default: 9001)
+    -h, --host [string]              Storybook server host. (default: localhost)
+    -s, --static-dir <dir-names>     Directory where to load static files from.
+    -c, --config-dir [dir-name]      Directory where to load Storybook configurations from. (default: .storybook)
+    -o, --output-dir [dir-name]      Directory where screenshot images are saved. (default: __screenshots__)
+    --parallel [number]              Number of Page Instances of Puppeteer to be activated when shooting screenshots. (default: 4)
+    --filter-kind [regexp]           Filter of kind with RegExp. (example: "Button$")
+    --filter-story [regexp]          Filter of story with RegExp. (example: "^with\s.+$")
+    --inject-files <file-names>      Path to the JavaScript file to be injected into frame. (default: )
+    --browser-timeout [number]       Timeout milliseconds when Puppeteer opens Storybook. (default: 30000)
+    --puppeteer-launch-config [json] JSON string of launch config for Puppeteer. (default: {"args":["--no-sandbox","--disable-setuid-sandbox"]})
+    --silent                         Suppress standard output.
+    --debug                          Enable debug mode.
+    -h, --help                       output usage information
 ```
 
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ program
   .option('--filter-story [regexp]', 'Filter of story with RegExp. (example: "^with\\s.+$")', parser.regexp)
   .option('--inject-files <file-names>', 'Path to the JavaScript file to be injected into frame.', parser.list, [])
   .option('--browser-timeout [number]', 'Timeout milliseconds when Puppeteer opens Storybook.', parser.number, 30000)
+  .option('--puppeteer-launch-config [json]', 'JSON string of launch config for Puppeteer.', parser.identity, '{"args":["--no-sandbox","--disable-setuid-sandbox"]}')
   .option('--silent', 'Suppress standard output.', parser.identity, false)
   .option('--debug', 'Enable debug mode.', parser.identity, false)
   .parse(process.argv);
@@ -45,6 +46,7 @@ const options: CLIOptions = {
   browserTimeout: program.browserTimeout,
   parallel: program.parallel,
   injectFiles: program.injectFiles,
+  puppeteerLaunchConfig: program.puppeteerLaunchConfig,
   silent: !!program.silent,
   debug: !!program.debug,
   ciMode: isCI,

--- a/src/core/app/Browser.ts
+++ b/src/core/app/Browser.ts
@@ -22,9 +22,7 @@ export default class Browser {
   }
 
   public async launch() {
-    this.browser = await puppeteer.launch({
-      args: ['--no-sandbox', '--disable-setuid-sandbox'],
-    });
+    this.browser = await puppeteer.launch(JSON.parse(this.options.puppeteerLaunchConfig));
   }
 
   public async close() {

--- a/src/core/app/__tests__/cli-options.mock.ts
+++ b/src/core/app/__tests__/cli-options.mock.ts
@@ -11,6 +11,7 @@ export const cliOptions: CLIOptions = {
   browserTimeout: 10000,
   parallel: 4,
   injectFiles: [],
+  puppeteerLaunchConfig: '{"args":["--no-sandbox","--disable-setuid-sandbox"]}',
   silent: false,
   debug: false,
   ciMode: false,

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -14,6 +14,7 @@ export interface CLIOptions {
   browserTimeout: number;
   parallel: number;
   injectFiles: string[];
+  puppeteerLaunchConfig: string;
   silent: boolean;
   debug: boolean;
   ciMode: boolean;


### PR DESCRIPTION
This is useful if you need specific flags for taking the screenshots, such as when using a particular server configuration, when needing to enable WebGL, etc.