### PR TITLE
Fix: Use the height that has been set in the viewport config for the screenshot

### DIFF
--- a/src/core/app/Page.ts
+++ b/src/core/app/Page.ts
@@ -56,10 +56,7 @@ export class Page extends EventEmitter {
   public async screenshot(story: StoredStory) {
     const { cwd, outputDir, injectFiles } = this.options;
 
-    await this.page.setViewport({
-      ...story.viewport,
-      height: 1
-    });
+    await this.page.setViewport(story.viewport);
 
     await Promise.all([
       this.waitComponentReady(),

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -24,7 +24,7 @@ export const defaultScreenshotOptions: ScreenshotOptions = {
   delay: 0,
   viewport: {
     width: 1024,
-    height: 768,
+    height: 1,
     deviceScaleFactor: 1,
     isMobile: false,
     hasTouch: false,


### PR DESCRIPTION
Hello,

I'm running across an issue where the current default behavior of taking a screenshot at the same height of the page is causing the image of a modal to be truncated. This seems to be because `documentElement.scrollHeight` (used [here](https://github.com/tsuyoshiwada/storybook-chrome-screenshot/blob/master/src/core/client/Client.ts#L60)) does not return consistent results across browsers.

This PR proposes a change where it uses the height that has been set in the viewport config for the screenshot and only defaults to using the height of the page if nothing has been set.

Thank you for taking the time to look at this.


